### PR TITLE
v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/histogram-date-range",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/histogram-date-range",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-activity-indicator": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/histogram-date-range",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Internet Archive histogram date range picker",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Version adds `binSnapping` and `tooltipDateFormat` properties to the component, for enforcing bin boundaries at month/year endpoints and for setting the format used in tooltips, respectively.