### PR TITLE
WEBDEV-8495 Ensure `histogramDateRangeUpdated` event is emitted for Lit 3

### DIFF
--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -204,7 +204,6 @@ export class HistogramDateRange extends LitElement {
       ) + this.snapEndOffset;
 
     this._binWidth = this._histWidth / this._numBins;
-    this._previousDateRange = this.currentDateRangeString;
     this._histData = this.calculateHistData();
     this.minSelectedDate = this.minSelectedDate
       ? this.minSelectedDate

--- a/test/histogram-date-range.test.ts
+++ b/test/histogram-date-range.test.ts
@@ -436,6 +436,25 @@ describe('HistogramDateRange', () => {
     expect(eventCount).to.equal(1); // only one event was fired
   });
 
+  it('emits a custom event when sliders are dragged to a new range', async () => {
+    const el = await createCustomElementInHTMLContainer();
+    el.updateDelay = 0;
+    await el.updateComplete;
+
+    const minSlider = el.shadowRoot?.querySelector('#slider-min') as SVGElement;
+
+    const updateEventPromise = oneEvent(el, 'histogramDateRangeUpdated');
+
+    // simulate dragging the min slider to the right and releasing
+    minSlider.dispatchEvent(new PointerEvent('pointerdown'));
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 75 }));
+    window.dispatchEvent(new PointerEvent('pointerup'));
+
+    const { detail } = await updateEventPromise;
+    expect(detail.minDate).to.equal('5/21/1950');
+    expect(detail.maxDate).to.equal('12/4/2020');
+  });
+
   it('shows/hides tooltip when hovering over (or pointing at) a bar', async () => {
     const el = await createCustomElementInHTMLContainer();
     // include a number which will require commas (1,000,000)


### PR DESCRIPTION
When the Lit version is overridden to Lit 3, the behavior of reactive get/set properties is altered subtly such that changes to those properties automatically call `requestUpdate()` rather than relying on the consumer to handle this in the setter. In the case of this component, when the user sets a new value, this earlier update is producing a state where the previous date range gets overwritten with the new one _before_ we compare the two to determine whether to emit an event. We then end up early-returning without emitting the event because the component believes no meaningful change has occurred.

This PR solves that issue by removing a premature assignment of the new date range to `_previousDateRange`, instead relying on it only being set when we actually intend to emit an update event.